### PR TITLE
Optimize frontend dockerfile

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,11 +3,13 @@ FROM node:18-alpine
 ARG ENV
 ENV REACT_APP_ENV $ENV
 
-WORKDIR /frontend
-COPY . .
-
-# Install dependencies and build
+# Install dependencies
+WORKDIR /app
+COPY package.json package-lock.json /app/
 RUN npm install
+
+# Copy the rest and build
+COPY . /app
 RUN npm run build
 
 EXPOSE 3000


### PR DESCRIPTION
The current docker build has an overhead on [`npm install`](https://github.com/collebrusco/ECE-461L-Orange/blob/339036aa4ca1bea0fadac55a8f1a75d21d1d0746/frontend/Dockerfile#L10) when the frontend codebase changes, and this PR can cache this process so that we only need re-install dependencies when changes are made on `package.json` and `package-lock.json`.

Reference: [How to cache the RUN npm install instruction when docker build a Dockerfile](https://stackoverflow.com/questions/35774714/how-to-cache-the-run-npm-install-instruction-when-docker-build-a-dockerfile)
